### PR TITLE
Fix for printf fire bug

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""A simple python script template.
+"""Server client script
 """
 
 from __future__ import print_function

--- a/document.md
+++ b/document.md
@@ -1,0 +1,1 @@
+This is a test document.

--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""A simple python script template.
+"""Server script
 """
 
 from __future__ import print_function


### PR DESCRIPTION
This fixes issue #1.

The bug was an erroneous call to `set_fire_to_board()` in the `printf` code. This has been removed.